### PR TITLE
Dynamic camera settings

### DIFF
--- a/compile_pi.sh
+++ b/compile_pi.sh
@@ -2,5 +2,5 @@
 if [ -z "$PI_ADDR" ]; then PI_ADDR=team5708pi.local; fi
 if [ -z "$PORT" ]; then PORT=22; fi
 
-rsync -rc -e "ssh -p $PORT" `dirname $0`"/src" "pi@"$PI_ADDR":./vision-code/"
-ssh pi@$PI_ADDR -p $PORT "cd ~/vision-code/src && make build -j4 && make install"
+rsync -rc -e "ssh -p $PORT" `dirname $0`"/src" "pi@"$PI_ADDR":./vision-code/$(git rev-parse --abbrev-ref HEAD)/"
+ssh pi@$PI_ADDR -p $PORT "cd ~/vision-code/$(git rev-parse --abbrev-ref HEAD)/src && make build -j4 && make install"

--- a/src/ControlPacketReceiver.cpp
+++ b/src/ControlPacketReceiver.cpp
@@ -1,0 +1,80 @@
+#include "ControlPacketReceiver.hpp"
+#include <string>
+#include <iostream>
+#include <fcntl.h>
+#include <chrono>
+#include <thread>
+
+#include <opencv2/imgproc.hpp>
+
+#include <unistd.h>
+#include <signal.h>
+#include <sys/wait.h>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+
+void ControlPacketReceiver::start(){
+    int retval=setupSocket();
+    std::cout << "@setupSocket(): " << retval << std::endl;
+    receiverThread=std::thread(&ControlPacketReceiver::receivePackets,this);
+}
+int ControlPacketReceiver::setupSocket(){
+    servFd = socket(AF_INET6, SOCK_STREAM, 0);
+	if (servFd < 0) {
+		perror("socket");
+		return -1;
+	}
+	
+	int flag = 1;
+	if (setsockopt(servFd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag)) == -1) {
+		perror("setsockopt");
+        return -1;
+	}
+
+    struct sockaddr_in6 servAddr;
+	memset(&servAddr, 0, sizeof(servAddr));
+	
+	servAddr.sin6_family = AF_INET6;
+	servAddr.sin6_addr = in6addr_any;
+	servAddr.sin6_port = htons(58000); //Port that the control stream uses
+
+	if (bind(servFd, (struct sockaddr*)&servAddr, sizeof(servAddr)) == -1) {
+		perror("bind");
+		return -1;
+	}
+	if (listen(servFd, 10)== -1) {
+		perror("listen");
+		return -1;
+	}
+    return 0;
+}
+
+void ControlPacketReceiver::receivePackets(){
+    std::cout << "@ReceivePackets thread started" << std::endl;
+    while (true) {
+		struct sockaddr_in6 clientAddr;
+		socklen_t clientAddrLen = sizeof(clientAddr);
+		int clientFd = accept(servFd, (struct sockaddr*) &clientAddr, &clientAddrLen);
+		if (clientFd < 0) {
+			perror("accept");
+			continue;
+		}
+
+        char controlMessage[65536];
+        ssize_t len = read(clientFd, controlMessage, sizeof(controlMessage)-1);
+        controlMessage[len] = '\0'; //Nullchar-delimit our message.
+        parsePacket(controlMessage);
+    }
+
+}
+
+void ControlPacketReceiver::parsePacket(char* controlMessage){
+    std::cout << controlMessage << std::endl;
+}
+
+
+    

--- a/src/ControlPacketReceiver.cpp
+++ b/src/ControlPacketReceiver.cpp
@@ -64,16 +64,23 @@ void ControlPacketReceiver::receivePackets(){
 			continue;
 		}
 
-        char controlMessage[65536];
-        ssize_t len = read(clientFd, controlMessage, sizeof(controlMessage)-1);
-        controlMessage[len] = '\0'; //Nullchar-delimit our message.
-        parsePacket(controlMessage);
+		while(true){
+			char controlMessage[65536];
+			ssize_t len = read(clientFd, controlMessage, sizeof(controlMessage)-1);
+			if(len<0) break; //Our connection has been broken.
+			controlMessage[len] = '\0'; //Nullchar-delimit our message.
+			const char* status = parsePacket(controlMessage);
+			int retval=write(clientFd,status,strlen(status));
+			if(retval<0) break;
+		}
     }
 
 }
 
-void ControlPacketReceiver::parsePacket(char* controlMessage){
+const char* ControlPacketReceiver::parsePacket(char* controlMessage){
     std::cout << controlMessage << std::endl;
+	const char* message=controlMessage;
+	return message;
 }
 
 

--- a/src/ControlPacketReceiver.cpp
+++ b/src/ControlPacketReceiver.cpp
@@ -17,9 +17,10 @@
 #include <netdb.h>
 #include <arpa/inet.h>
 #include <functional>
+#include <string>
 
 
-ControlPacketReceiver::ControlPacketReceiver(std::function<const char*(char*)> parsePacketCallback,short port){
+ControlPacketReceiver::ControlPacketReceiver(std::function<std::string(char*)> parsePacketCallback,short port){
 	this->port=port;
 	this->parsePacketCallback=parsePacketCallback;
 	start();
@@ -85,9 +86,10 @@ void ControlPacketReceiver::receivePackets(){
 			} 
 			std::cout << "Received control message " << controlMessage << std::endl;
 			controlMessage[len] = '\0'; //Nullchar-delimit our message.
-			const char* status = parsePacketCallback(controlMessage); //Send the control packet to our external packet-parsing function.
-			std::cout << "Control Message status: " << status << std::endl;
-			int retval=write(clientFd,status,strlen(status));
+			std::string status = parsePacketCallback(controlMessage); //Send the control packet to our external packet-parsing function.
+			const char * status_c_str = status.c_str();
+			std::cout << "Control Message status: \n" << status_c_str << std::endl;
+			int retval=write(clientFd,status_c_str,strlen(status_c_str));
 			if(retval<0){
 				std::cout << "Connection to controller broken." << std::endl;
 				break;

--- a/src/ControlPacketReceiver.hpp
+++ b/src/ControlPacketReceiver.hpp
@@ -8,16 +8,23 @@
 #include <cstring>
 #include <functional>
 
-
+/* ControlPacketReceiver(std::function<const char*(char*)> parsePacketCallback, short port=58000)
+** This class sets up a listening tcp socket on the specified port (58000 if not specified) 
+** and sends received messages to the callback function provided to its constructor.
+** If the connection is interrupted, it will wait for it to be re-established.
+** This class logs its operations to stdout.
+*/
 class ControlPacketReceiver{
 private:
     int servFd=-1;
     short port;
     std::thread receiverThread;
+    bool destroyReceiver=false; //Gets set to true when receiver's destructor is called. This is so we can properly clean up the network socket we create.
     int setupSocket(); //Initializes network socket.
     void receivePackets(); //Self-resetting loop that receives control packets. Runs on a seperate thread.
-    std::function<const char*(char* controlMessage)> parsePacket; //Callback function that parses control messages received.
+    std::function<const char*(char* controlMessage)> parsePacketCallback; //Callback function that parses control messages received.
 public:
-    ControlPacketReceiver(std::function<const char*(char*)> parsePacket,short port=58000);
+    ControlPacketReceiver(std::function<const char*(char*)> parsePacketCallback,short port=58000);
+    ~ControlPacketReceiver();
     void start();
 };

--- a/src/ControlPacketReceiver.hpp
+++ b/src/ControlPacketReceiver.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <fcntl.h>
+#include <thread>
+#include <cstring>
+
+
+class ControlPacketReceiver{
+    int servFd=-1;
+    std::thread receiverThread;
+    public:
+    void start();
+    int setupSocket();
+    void receivePackets();
+    void parsePacket(char* controlMessage);
+};

--- a/src/ControlPacketReceiver.hpp
+++ b/src/ControlPacketReceiver.hpp
@@ -15,5 +15,5 @@ class ControlPacketReceiver{
     void start();
     int setupSocket();
     void receivePackets();
-    void parsePacket(char* controlMessage);
+    const char* parsePacket(char* controlMessage);
 };

--- a/src/ControlPacketReceiver.hpp
+++ b/src/ControlPacketReceiver.hpp
@@ -6,14 +6,18 @@
 #include <fcntl.h>
 #include <thread>
 #include <cstring>
+#include <functional>
 
 
 class ControlPacketReceiver{
+private:
     int servFd=-1;
+    short port;
     std::thread receiverThread;
-    public:
+    int setupSocket(); //Initializes network socket.
+    void receivePackets(); //Self-resetting loop that receives control packets. Runs on a seperate thread.
+    std::function<const char*(char* controlMessage)> parsePacket; //Callback function that parses control messages received.
+public:
+    ControlPacketReceiver(std::function<const char*(char*)> parsePacket,short port=58000);
     void start();
-    int setupSocket();
-    void receivePackets();
-    const char* parsePacket(char* controlMessage);
 };

--- a/src/ControlPacketReceiver.hpp
+++ b/src/ControlPacketReceiver.hpp
@@ -7,6 +7,7 @@
 #include <thread>
 #include <cstring>
 #include <functional>
+#include <string>
 
 /* ControlPacketReceiver(std::function<const char*(char*)> parsePacketCallback, short port=58000)
 ** This class sets up a listening tcp socket on the specified port (58000 if not specified) 
@@ -22,9 +23,9 @@ private:
     bool destroyReceiver=false; //Gets set to true when receiver's destructor is called. This is so we can properly clean up the network socket we create.
     int setupSocket(); //Initializes network socket.
     void receivePackets(); //Self-resetting loop that receives control packets. Runs on a seperate thread.
-    std::function<const char*(char* controlMessage)> parsePacketCallback; //Callback function that parses control messages received.
+    std::function<std::string(char* controlMessage)> parsePacketCallback; //Callback function that parses control messages received.
 public:
-    ControlPacketReceiver(std::function<const char*(char*)> parsePacketCallback,short port=58000);
+    ControlPacketReceiver(std::function<std::string(char*)> parsePacketCallback,short port=58000);
     ~ControlPacketReceiver();
     void start();
 };

--- a/src/DataComm.cpp
+++ b/src/DataComm.cpp
@@ -65,8 +65,8 @@ void DataComm::setupSocket() {
     }
 }
 DataComm::DataComm(const char* client_name, const char* port="5808") : client_name(client_name) {
-    setupSocket();
     this->port=port;
+    setupSocket();
 }
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,7 @@ ODIR=obj
 %.o: %.cpp %.hpp
 	g++ -c -o $@ $< $(CXXFLAGS)
 
-OBJS=main.o RedContourGrip.o vision.o streamer.o DataComm.o VideoHandler.o
+OBJS=main.o RedContourGrip.o vision.o streamer.o DataComm.o VideoHandler.o ControlPacketReceiver.o
 
 build: $(OBJS)
 	g++ -Wno-psabi $(COMMON_FLAGS) -o ../5708-vision $(OBJS) -lm -ldl `pkg-config --libs opencv4` -pthread

--- a/src/VideoHandler.cpp
+++ b/src/VideoHandler.cpp
@@ -315,7 +315,7 @@ void ThreadedVideoReader::reset(){
 */
 int ThreadedVideoReader::setResolution(unsigned int width,unsigned int height){
 	bool foundValidResolution=false;
-	for(auto& res : resolutions){
+	for(auto& res : resolutions){ //Yes, this is less efficient than it could be, but we're talking about with a list with <50 items here.
 		if(res.discrete.width==width && res.discrete.height==height){
 			foundValidResolution=true; 
 			break;
@@ -323,8 +323,10 @@ int ThreadedVideoReader::setResolution(unsigned int width,unsigned int height){
 	}
 	if(!foundValidResolution) return 1; //Given resolution is invalid.
 	this->width=width; this->height=height;
+	std::cout << "Changing resolution to " << width << ":" << height << " ..." << std::endl;
 	reset();
-	return 0; //Not implemented.
+	std::cout << "Succesfully reset resolution" << std::endl;
+	return 0;
 }
 
 

--- a/src/VideoHandler.cpp
+++ b/src/VideoHandler.cpp
@@ -17,8 +17,8 @@ Magic and jankyness lies here. This class communicates to the cameras and to gSt
  haven't tested (especially non-usb cameras) might not work.
 */
 
-VideoReader::VideoReader(int width, int height, const char* file) {
-	this->width = width; this->height = height; deviceFile = file;
+VideoReader::VideoReader(int width, int height, const char* file) : deviceFile(std::string(file)){
+	this->width = width; this->height = height;
 }
 bool VideoReader::tryOpenReader() {
 
@@ -295,16 +295,20 @@ void ThreadedVideoReader::resetterMonitor(){ // Seperate thread that resets the 
 		std::this_thread::sleep_for(std::chrono::milliseconds(100)); // Because I'm a janky spinlock
 	}
 }
-void ThreadedVideoReader::reset(){
-	resetLock.lock();
-	
+void VideoReader::reset(){
 	closeReader();
 	sleep(4);
 	openReader();
-
+}
+void ThreadedVideoReader::reset(){
+	resetLock.lock();
+	VideoReader::reset();
 	last_update = timeout_clock.now();
-
 	resetLock.unlock();
+
+}
+const std::chrono::steady_clock::time_point ThreadedVideoReader::getLastUpdate(){
+	return last_update;
 }
 /* int ThreadedVideoReader::setResolution(int width, int height)
 ** This function attempts to set the resolution of the camera stream to the given values, 

--- a/src/VideoHandler.cpp
+++ b/src/VideoHandler.cpp
@@ -297,7 +297,7 @@ void ThreadedVideoReader::resetterMonitor(){ // Seperate thread that resets the 
 }
 void VideoReader::reset(){
 	closeReader();
-	sleep(4);
+	sleep(2); //Can this be lowered? I've changed it from 4 to 2, here's hoping it doesn't make anything explode...
 	openReader();
 }
 void ThreadedVideoReader::reset(){

--- a/src/VideoHandler.hpp
+++ b/src/VideoHandler.hpp
@@ -56,10 +56,9 @@ public:
 	void setExposure(int value) { setExposureVals(false, value); }
 	// Turns on auto-exposure.
 	void setAutoExposure() { setExposureVals(true, 50); }
-	int setResolution(int width, int height);
 
 	void queryResolutions();
-	std::vector<resolution> resolutions;
+	std::vector<resolution> resolutions; //Front is also discrete, back stepwise! This is not obvious.
 
 	class NotInitializedException : public std::exception {};
 };
@@ -73,10 +72,12 @@ public:
 	std::chrono::steady_clock::time_point last_update;
 	volatile bool hasNewFrame = false;
 	virtual ~ThreadedVideoReader() {}; //Does nothing; required to compile?
+	int setResolution(unsigned int width, unsigned int height);
+	void reset(); //Actually resets the camera. 
 private:
 	std::chrono::steady_clock timeout_clock;
 
-	void resetterMonitor();
+	void resetterMonitor(); //Monitors to see if camera should be reset, calls reset() if it should be so.
 	// Only reset the camera if it's been dead for over this amount of time.
 	static constexpr std::chrono::steady_clock::duration ioctl_timeout = std::chrono::milliseconds(5000); 
 	std::mutex resetLock;

--- a/src/VideoHandler.hpp
+++ b/src/VideoHandler.hpp
@@ -11,6 +11,12 @@
 // Some helper classes to interface with the Video4Linux (V4L2) API
 
 
+//Magic struct.
+struct resolution {
+	int type;
+	v4l2_frmsize_discrete discrete; //Only one of these two is actually going to be initialized. FSCK unions.
+	v4l2_frmsize_stepwise stepwise;
+};
 
 // Reads video from a camera
 class VideoReader {
@@ -50,6 +56,10 @@ public:
 	void setExposure(int value) { setExposureVals(false, value); }
 	// Turns on auto-exposure.
 	void setAutoExposure() { setExposureVals(true, 50); }
+	int setResolution(int width, int height);
+
+	void queryResolutions();
+	std::vector<resolution> resolutions;
 
 	class NotInitializedException : public std::exception {};
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -305,7 +305,7 @@ int main(int argc, char** argv) {
 	std::function<const char*(char*)> simplecallback = [](char* message){
 		return message;
 	};
-	ControlPacketReceiver test = ControlPacketReceiver(simplecallback,58000);
+	ControlPacketReceiver test = ControlPacketReceiver(std::bind(&Streamer::parseControlMessage,&streamer,std::placeholders::_1),58000);
 	// never returns
 	streamer.run();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -302,9 +302,10 @@ int main(int argc, char** argv) {
 
 	//std::thread visThread(&VisionThread);
 	std::thread controlSockThread(&ControlSocket);
-
-	ControlPacketReceiver test;
-	test.start();
+	std::function<const char*(char*)> simplecallback = [](char* message){
+		return message;
+	};
+	ControlPacketReceiver test = ControlPacketReceiver(simplecallback,58000);
 	// never returns
 	streamer.run();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@
 #include "streamer.hpp"
 
 #include "DataComm.hpp"
+#include "ControlPacketReceiver.hpp"
 
 using std::cout; using std::cerr; using std::endl; using std::string;
 
@@ -46,6 +47,7 @@ void visionFrameNotifier(); //Declared later in namespace
 Streamer streamer(visionFrameNotifier);
 
 // recieves enable/disable signals from the RIO to conserve thermal capacity
+// Also allows control packets to be sent to modify camera values.
 // Also sets exposure when actively driving to target
 void ControlSocket() {
 	struct addrinfo hints;
@@ -276,8 +278,7 @@ int main(int argc, char** argv) {
 		cerr << "usage: " << argv[0] << "[test image] [calibration parameters]" << endl;
 		return 1;
 	}
-	// Enables the v4l2loopback kernel module if it hasn't already
-	system("/home/pi/bin/run_setup_v4l2loopback");
+
 	
 	// SIGPIPE is sent to the program whenever a connection terminates. We want the program to stay alive if a connection unexpectedly terminates.
 	signal(SIGPIPE, SIG_IGN);
@@ -302,6 +303,8 @@ int main(int argc, char** argv) {
 	//std::thread visThread(&VisionThread);
 	std::thread controlSockThread(&ControlSocket);
 
+	ControlPacketReceiver test;
+	test.start();
 	// never returns
 	streamer.run();
 

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -401,7 +401,7 @@ void Streamer::pushFrame(int i) {
 		if (elapsed >= std::chrono::seconds(1)) {
 			cout << "In the past " << std::chrono::duration_cast<std::chrono::duration<double>>(elapsed).count()
 			<< " seconds, " << frameCount << " pushed frames: ";
-			for (int i = 0; i < cameraFrameCounts.size(); ++i) {
+			for (unsigned int i = 0; i < cameraFrameCounts.size(); ++i) {
 				cout << cameraFrameCounts[i] << " from cam " << i;
 				if (i != cameraFrameCounts.size() - 1) cout << ", ";
 				cameraFrameCounts[i] = 0;

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -419,8 +419,7 @@ void Streamer::pushFrame(int i) {
 	frameLock.unlock();
 }
 
-const char * Streamer::parseControlMessage(char * message){
-	std::cout << "@parseControlMessage: " << message <<  std::endl;
+string Streamer::parseControlMessage(char * message){
 	/*Control message syntax: Camerano1,[camerano2,...]:CONTROL MESSAGE
 	**Returned status syntax: 
 	**	Camerano1:RETNO:STATUS MESSAGE
@@ -430,13 +429,13 @@ const char * Streamer::parseControlMessage(char * message){
 	**  UNPARSABLE MESSAGE
 	** RETNO is 0 upon success, something else upon failure (detrmined by videoHandler functions). The STATUS MESSAGE *SHOULD* return more information.
 	*/
-	std::stringstream status;
+	std::stringstream status=std::stringstream("");
 
 	string commandMessage=string(message);
 	unsigned int indexOfDelimiter=commandMessage.find(':');
 	if(indexOfDelimiter==string::npos){
 		//There just isn't a : in there.
-		status << "UNPARSABLE MESSAGE (No comma-seperator)";
+		status << "UNPARSABLE MESSAGE (No colon-seperator)";
 		return status.str().c_str(); //Delightful.
 	}
 	std::stringstream cameraSegment=std::stringstream(commandMessage.substr(0,indexOfDelimiter));
@@ -449,20 +448,20 @@ const char * Streamer::parseControlMessage(char * message){
 	}
 	if(cameras.size()==0){
 		//We didn't actually get any camera numbers.
-		status << "UNPARSABLE MESSAGE (No cameras specified)";
+		status << "UNPARSABLE MESSAGE (No cameras specified)\n";
 		return status.str().c_str(); //Delightful
 	}
 	for(string &i : cameras){
-		const char * return_status=controlMessage(i,command);
-		status << i << ":" << return_status << std::endl;
+		string return_status=controlMessage(i,command);
+		status << i << ":" << return_status << "\n";
 	}
-	return status.str().c_str(); //Delightful.
+	return status.str(); //Delightful.
 
 }
-const char * Streamer::controlMessage(string camera, string command){
-	std::stringstream status;
-	status << camera << ":" << "Command \"" << command << "\" not implemented yet." << std::endl;
-	return status.str().c_str();
+string Streamer::controlMessage(string camera, string command){
+	std::stringstream status=std::stringstream("");
+	status << "Command \"" << command << "\" not implemented yet.";
+	return status.str();
 }
 void Streamer::run() {
 	// defunct; doesn't do anything anymore

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -270,7 +270,7 @@ void Streamer::dsListener() {
 		socklen_t clientAddrLen = sizeof(clientAddr);
 		int clientFd = accept(servFd, (struct sockaddr*) &clientAddr, &clientAddrLen);
 		if (clientFd < 0) {
-			perror("accept");
+			perror("accept (gstreamer)");
 			continue;
 		}
 
@@ -390,7 +390,7 @@ bool Streamer::checkFramebufferReadiness(){
 	
 	for(unsigned int i=0;i<cameraDevs.size();i++){
 		// if there is no new frame from the camera, but the camera is not dead, return false
-		if(!readyState[i] && time - cameraReaders[i]->last_update < std::chrono::milliseconds(45)){
+		if(!readyState[i] && time - cameraReaders[i]->getLastUpdate() < std::chrono::milliseconds(45)){
 			return false;
 		}
 	}

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -289,7 +289,7 @@ void Streamer::dsListener() {
 		}
 		
 		char bitrate[16];
-		ssize_t len = read(clientFd, bitrate, sizeof(bitrate));
+		ssize_t len = read(clientFd, bitrate, sizeof(bitrate)-1);
 		bitrate[len] = '\0';
 		
 		const char message[] = "Launching remote GStreamer...\n";

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -534,6 +534,13 @@ string Streamer::parseControlMessage(char * message){
 
 }
 string Streamer::controlMessage(string camera_string, string command){
+	/*TODO: implement
+	**     if (msgStr.find("ENABLE") != string::npos) visionEnabled = true;
+			if (msgStr.find("DISABLE") != string::npos) visionEnabled = false;
+			if (msgStr.find("DRIVEON") != string::npos) streamer.setLowExposure(true);
+			if (msgStr.find("DRIVEOFF") != string::npos) streamer.setLowExposure(false);
+	** from obsolete function in main
+	*/		
 
 	std::stringstream status=std::stringstream("");
 	int cam_no;
@@ -547,7 +554,7 @@ string Streamer::controlMessage(string camera_string, string command){
 	}
 
 	//Resolution command
-	if(command.substr(0,10).compare("resolution")==0){
+	if(false/*command.substr(0,10).compare("resolution")==0*/){//Not implemented yet! Currently attempting to change video resolutions *horrifically* crashes the program.
 		std::stringstream toParse=std::stringstream(command);
 		string buffer;
 		toParse >> buffer; //Dispose of the command name

--- a/src/streamer.hpp
+++ b/src/streamer.hpp
@@ -80,7 +80,7 @@ public:
 	bool lowExposure = false;
 	void setLowExposure(bool value);
 	cv::Mat frameBuffer;
-	const char * parseControlMessage(char * commandMessage); //Callback function passed into ControlPacketReceiver. Parses control messages to send to appropriate camera/s
-	const char * controlMessage(std::string camera, std::string command);
+	std::string parseControlMessage(char * commandMessage); //Callback function passed into ControlPacketReceiver. Parses control messages to send to appropriate camera/s
+	std::string controlMessage(std::string camera, std::string command);
 };
 extern int clientFd; 

--- a/src/streamer.hpp
+++ b/src/streamer.hpp
@@ -10,6 +10,7 @@
 #include "vision.hpp"
 #include "DataComm.hpp"
 #include "VideoHandler.hpp"
+#include <string>
 
 // Starts and manages gStreamer processes
 // Also intercepts the video stream from one camera to feed into vision processing
@@ -79,5 +80,7 @@ public:
 	bool lowExposure = false;
 	void setLowExposure(bool value);
 	cv::Mat frameBuffer;
+	const char * parseControlMessage(char * commandMessage); //Callback function passed into ControlPacketReceiver. Parses control messages to send to appropriate camera/s
+	const char * controlMessage(std::string camera, std::string command);
 };
 extern int clientFd; 


### PR DESCRIPTION
Note -- this is almost entirely refactoring, without any *new* functionality added.
Various bugs were fixed preemptively.
Additionally, this adds in the stable, working ControlPacketReceiver class.
There are currently no working and implemented commands. (The set resolution command has been intentionally disabled, because our streaming code currently doesn't account for the possibility of the camera resolution changing on it.)
However, implementing new commands is incredibly simple. (I'll continue to do so in dynamic_camera_settings).